### PR TITLE
Fix dataset label check for pie charts

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/PieChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartData.swift
@@ -76,7 +76,8 @@ open class PieChartData: ChartData
         
         if ignorecase
         {
-            if let label = dataSets[0].label, label.caseInsensitiveCompare(label) == .orderedSame
+            if let dataSetLabel = dataSets[0].label,
+               dataSetLabel.caseInsensitiveCompare(label) == .orderedSame
             {
                 return dataSets[0]
             }


### PR DESCRIPTION
## Summary
- ensure `dataSet(forLabel:ignorecase:)` compares the dataset label with the provided label

## Testing
- `swift test` *(fails: no such module 'CoreGraphics')*

------
https://chatgpt.com/codex/tasks/task_e_68483d1f8650832eac47d47d08cdc7db